### PR TITLE
Open day menu on hover and change anchor to link icon.

### DIFF
--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -105,7 +105,7 @@
                   <h4 class="session-title">
                     {{title}}&nbsp;
                     <a class="session-link" href="#{{session_id}}">
-                      <i class="fa fa-anchor"></i>
+                      <i class="fa fa-link"></i>
                     </a>
                   </h4>
                   <p class="session-location">

--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -52,7 +52,7 @@
         <div class="collapse navbar-collapse" id="navbar">
           <ul class="nav navbar-nav">
             {{#days}}
-            <li class="dropdown">
+            <li class="dropdown" id="day-menu">
               <a
               href="#"
               class="dropdown-toggle"


### PR DESCRIPTION
This changes `fa-anchor` to `fa-link` as suggested by @mariobehling . Fixes OpenTechSummit/2016.opentechsummit.net#9.

**Screenshot:**
![capture](https://cloud.githubusercontent.com/assets/2404372/14808873/8c15c810-0ba6-11e6-9e94-8247cba3634f.PNG)

Also, the an ID addition for the day menu has been added to enable open on hover.
