### PR TITLE
Linkifying links in description

### DIFF
--- a/schedule/generator.js
+++ b/schedule/generator.js
@@ -8,6 +8,23 @@ const tpl = handlebars.compile(fs.readFileSync(__dirname + '/schedule.tpl').toSt
 const sessionsData = require('../out/sessions.json')
 const speakersData = require('../out/speakers.json')
 
+if(!String.linkify) {
+    String.prototype.linkify = function() {
+        var urlPattern = /\b(?:https?|ftp):\/\/[a-z0-9-+&@#\/%?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|]/gim;
+        var pseudoUrlPattern = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
+        var emailAddressPattern = /[\w.]+@[a-zA-Z_-]+?(?:\.[a-zA-Z]{2,6})+/gim;
+        return this
+            .replace(urlPattern, '<a href="$&">$&</a>')
+            .replace(pseudoUrlPattern, '$1<a href="http://$2">$2</a>')
+            .replace(emailAddressPattern, '<a href="mailto:$&">$&</a>');
+    };
+}
+
+handlebars.registerHelper('linkify', function (options) {
+    var content = options.fn(this);
+    return new handlebars.SafeString(content.linkify());
+});
+
 function slugify(str) {
   return str.replace(/[^\w]/g, '-').replace(/-+/g, '-').toLowerCase()
 }

--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -135,7 +135,7 @@
                     </p>
                     <div class="session-speakers-more">
                       <p>
-                        <span class="session-speaker-bio">{{biography}}</span>
+                        <span class="session-speaker-bio">{{#linkify}}{{biography}}{{/linkify}}</span>
                       </p>
                       <p class="session-speaker-social">
                         {{#if web}}

--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -105,7 +105,7 @@
                   <h4 class="session-title">
                     {{title}}&nbsp;
                     <a class="session-link" href="#{{session_id}}">
-                      <i class="fa fa-anchor"></i>
+                      <i class="fa fa-link"></i>
                     </a>
                   </h4>
                   <p class="session-location">

--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -52,7 +52,7 @@
         <div class="collapse navbar-collapse" id="navbar">
           <ul class="nav navbar-nav">
             {{#days}}
-            <li class="dropdown">
+            <li class="dropdown" id="day-menu">
               <a
               href="#"
               class="dropdown-toggle"


### PR DESCRIPTION
Any link/url in the description is automatically made into a clickable link when the html is generated by the scrapper. Fixes OpenTechSummit/2016.opentechsummit.net#7 

_As suggested by @mariobehling_
