### PR TITLE
Loading fontawesome and Open Sans font over https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,5 @@ target/
 node_modules/
 .env
 
-
+.idea
 fa16-repo/

--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -20,8 +20,8 @@
   <!-- Latest compiled and minified CSS -->
   <link rel="shortcut icon" href="../fossasia.ico" type="image/x-icon" />
   <link href="../css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
-  <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
 
   <link rel="stylesheet" href="../css/schedule.css">
 


### PR DESCRIPTION
This PR changes `schedule.tpl` so that FontAwesome and OpenSans font are loaded over `https` instead of `http`. This would prevent _Unsafe scripts_ error if and when [opentechsummit.net](http://opentechsummit.net) starts using SSL. 
