### PR TITLE
changes due to self-schedule

### DIFF
--- a/schedule/schedule.tpl
+++ b/schedule/schedule.tpl
@@ -19,11 +19,11 @@
   <!-- Bootstrap core CSS -->
   <!-- Latest compiled and minified CSS -->
   <link rel="shortcut icon" href="{{ eventurls.ico_url }}" type="image/x-icon" />
-  <link href="../css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
+  <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
   <link href='//fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
 
-  <link rel="stylesheet" href="../css/schedule.css">
+  <link rel="stylesheet" href="css/schedule.css">
 
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
Regarding the PR https://github.com/OpenTechSummit/2016.opentechsummit.net/pull/60 and issue https://github.com/OpenTechSummit/2016.opentechsummit.net/issues/59 . 
Now the CSS inside Schedule is no longer dependent on the parent folders.
